### PR TITLE
Fixed header game setup

### DIFF
--- a/src/renderer/components/game-setup/GameSetupGrid.vue
+++ b/src/renderer/components/game-setup/GameSetupGrid.vue
@@ -41,6 +41,9 @@ header
   align-items: center
   justify-content: flex-end
   padding: 0 30px
+  position: sticky
+  top: 0
+  z-index: 10
 
   +theme using ($theme)
     background-color: map-get($theme, 'cards-bg')
@@ -65,6 +68,8 @@ header
   display: flex
   align-items: center
   justify-content: center
+  position: sticky
+  top: 0
 
   +theme using ($theme)
     background-color: map-get($theme, 'cards-bg')

--- a/src/renderer/pages/game-setup.vue
+++ b/src/renderer/pages/game-setup.vue
@@ -10,12 +10,13 @@
 
       <HeaderGameButton title="Create" @click="createGame" />
 
-      <TilePackSize :size="$tiles.getPackSize(sets, rules)" />
     </template>
 
     <template #detail-header>
       <template>
         <h2 class="tile-pack-header">Selected tiles</h2>
+	    &nbsp;
+        <TilePackSize :size="$tiles.getPackSize(sets, rules)" />
       </template>
     </template>
 


### PR DESCRIPTION
When scrolling down for set Tile sets, it's important to go back.
When playing for zillionth times, it's very annoying to select sets with scroll down, and than scroll back to header to continue game.