### PR TITLE
Keep tunnel token color, not apply dark/ligh theme

### DIFF
--- a/src/renderer/components/game/PlayerPanel.vue
+++ b/src/renderer/components/game/PlayerPanel.vue
@@ -258,7 +258,7 @@ section
     .stacked
       margin-left: -24px
 
-  ::v-deep svg
+  ::v-deep svg:not(.tunnel)
     +theme using ($theme)
       fill: map-get($theme, 'cards-text')
 

--- a/src/renderer/store/game.js
+++ b/src/renderer/store/game.js
@@ -214,12 +214,12 @@ export const getters = {
     const fillCss = inactive ? 'color-inactive-fill' : 'color-fill'
     if (letter === 'A') {
       const { slot } = state.players[player]
-      return `color-${slot} ${fillCss} color-overlay`
+      return `color-${slot} ${fillCss} color-overlay tunnel`
     }
 
     const emptySlots = difference(range(9), state.players.map(p => p.slot))
     const slot = emptySlots[player + (letter === 'B' ? 0 : state.players.length)]
-    return `color-${slot} ${fillCss} color-overlay`
+    return `color-${slot} ${fillCss} color-overlay tunnel`
   },
 
   tileOn: state => pos => {


### PR DESCRIPTION
After apply light/dark theme token color is replaced by light/dark mask.
This change exclude changing color of tunnel tokens