### PR TITLE
fix order of final statistics for higher score than hundred

### DIFF
--- a/src/renderer/components/game/GameResultPanel.vue
+++ b/src/renderer/components/game/GameResultPanel.vue
@@ -34,8 +34,7 @@ export default {
         const playersWithIndex = state.game.players.map((p, index) => ({ ...p, index }))
         const groups = groupBy(playersWithIndex, 'points')
         const points = Object.keys(groups).map(p => parseInt(p))
-        points.sort()
-        points.reverse()
+        points.sort((a, b) => b - a)
         let rank = 0
         const ranks = []
         points.forEach(p => {


### PR DESCRIPTION
Original state
![image](https://user-images.githubusercontent.com/1339083/97365118-7403ab00-18a5-11eb-9b1a-297e352af383.png)


Fix order of final scores 
![image](https://user-images.githubusercontent.com/1339083/97364665-a8c33280-18a4-11eb-93dd-0fc32099ab35.png)


After patch
![image](https://user-images.githubusercontent.com/1339083/97364466-64d02d80-18a4-11eb-865b-867cd7cf7254.png)