### PR TITLE
Highlight allowed features in Action Phase.

### DIFF
--- a/src/renderer/components/game/layers/CastleBaseSelectLayer.vue
+++ b/src/renderer/components/game/layers/CastleBaseSelectLayer.vue
@@ -99,5 +99,5 @@ export default {
 
 <style lang="sass" scoped>
 .area.mouseout
-  opacity: 0
+  opacity: 0.25
 </style>

--- a/src/renderer/components/game/layers/FeatureSelectLayer.vue
+++ b/src/renderer/components/game/layers/FeatureSelectLayer.vue
@@ -147,5 +147,5 @@ export default {
 
 <style lang="sass" scoped>
 .area.mouseout
-  opacity: 0
+  opacity: 0.25
 </style>


### PR DESCRIPTION
Highlight allowed features in Action Phase for:

-     placing a figure
-     placing a Castle Token
-     scoring Acrobats.

Similar to Princess / Returning Abbot / Vodyanoy / Crop Circles when around figures which can be affected by selected action is showed circle.